### PR TITLE
Set up Jest testing infrastructure

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 lib/**
+coverage/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ language: node_js
 node_js:
   - "6"
 
-script: npm test
+script:
+  - npm run lint
+  - npm run test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "npm run build",
-    "test": "npm run lint",
+    "jest": "NODE_ENV=test jest --config test/jest-config.json --runInBand",
+    "test": "npm run --silent jest -- --runInBand=false",
+    "test:watch": "npm run --silent test -- --watch",
     "lint": "eslint ./",
     "build": "babel src --out-dir lib"
   },
@@ -32,13 +34,16 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.20.0",
     "babel-eslint": "^6.1.0",
+    "babel-jest": "^20.0.3",
     "babel-preset-react-native": "^1.9.0",
+    "chai": "^4.0.2",
     "eslint": "^3.11.1",
     "eslint-config-airbnb": "^12.0.0",
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-prefer-object-spread": "^1.0.0",
     "eslint-plugin-react": "^6.8.0",
+    "jest": "^20.0.4",
     "redux": "^3.6.0"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", {
+      "devDependencies": true,
+      "optionalDependencies": false,
+    }],
+  },
+  "env": {
+    "mocha": true
+  }
+}

--- a/test/createInjectableStore.test.js
+++ b/test/createInjectableStore.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+
+import { createInjectableStore } from '../src';
+
+const initialState = {};
+
+describe('createInjectableStore', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createInjectableStore(initialState);
+  });
+
+  it('returns a valid Redux store', () => {
+    expect(store).to.have.property('getState');
+    expect(store).to.have.property('dispatch');
+    expect(store).to.have.property('subscribe');
+    expect(store).to.have.property('replaceReducer');
+  });
+});

--- a/test/jest-config.json
+++ b/test/jest-config.json
@@ -1,0 +1,11 @@
+{
+  "bail": false,
+  "coverageReporters": ["json-summary", "lcov", "html"],
+  "testEnvironment": "node",
+  "testRegex": "test/.*\\.test\\.js$",
+  "rootDir": "..",
+  "roots": [
+    "./src",
+    "./test"
+  ]
+}


### PR DESCRIPTION
## Overview
Adds infrastructure for testing the library via Jest, with Chai
assertions. Updates the Travis config as appropriate, and adds a simple
test to start.

## Reviewers
@lelandrichardson 