### PR TITLE
Warn on injection into conflicting namespace, allow forcing injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v1.1.0
+
+- Add warning when an attempt is made to inject a reducer into an existing namespace.
+- Add `force` argument to `inject` and `injectAll` to allow forcing the injection of a reducer into an existing namespace.
+
+## v1.0.0
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ type ReduxStore<S, A> = {
 
 // This is a new "injectable" store with some extra methods
 type InjectableStore<S, A> = ReduxStore<S, A> & {
-  inject(namespace: string, reducer: Reducer<S, A>),
-  injectAll({ [key: string]: Reducer<S, A> }),
+  inject(namespace: string, reducer: Reducer<S, A>, force: boolean = false),
+  injectAll({ [key: string]: Reducer<S, A> }, force: boolean = false),
   clearReducers(),
 };
 
@@ -116,7 +116,7 @@ store.injectAll({
 
 ## Additional Notes
 
-1. If you try to inject a reducer into a namespace that already has a reducer, it will be a "no op".
+1. If you try to inject a reducer into a namespace that already has a reducer without passing the 'force' argument, it will `console.warn` and be a "no op".
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "eslint-plugin-prefer-object-spread": "^1.0.0",
     "eslint-plugin-react": "^6.8.0",
     "redux": "^3.6.0"
+  },
+  "dependencies": {
+    "warning": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-injectable-store",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Redux store with injectable reducers for use with bundle splitting, large apps, and SPAs.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/createInjectableStore.js
+++ b/src/createInjectableStore.js
@@ -1,4 +1,5 @@
 import { createStore, combineReducers } from 'redux';
+import warning from 'warning';
 
 const FAKE_INITIAL_REDUCER_NAMESPACE = '___';
 const IDENTITY_REDUCER = (state = null) => state;
@@ -23,20 +24,30 @@ const createInjectableStore = (preloadedState, enhancer, wrapReducer = defaultWr
     reducers = makeEmptyReducerMap();
   };
 
-  const inject = (namespace, reducer) => {
-    if (reducers[namespace] == null) {
-      reducers[namespace] = reducer;
-      replace();
+  const inject = (namespace, reducer, force = false) => {
+    if (reducers[namespace] != null && !force) {
+      warning(
+        false,
+        `Attempted to inject a new reducer in an already existing namespace ('${namespace}') without \`force\`. Skipping.`
+      );
+      return;
     }
+    reducers[namespace] = reducer;
+    replace();
   };
 
-  const injectAll = reducerMap => {
+  const injectAll = (reducerMap, force = false) => {
     let hasChanged = false;
     Object.keys(reducerMap).forEach(namespace => {
-      if (reducers[namespace] == null) {
-        reducers[namespace] = reducerMap[namespace];
-        hasChanged = true;
+      if (reducers[namespace] != null && !force) {
+        warning(
+          false,
+          'Attempted to inject a new reducer in an already existing namespace without `force`. Skipping.'
+        );
+        return;
       }
+      reducers[namespace] = reducerMap[namespace];
+      hasChanged = true;
     });
     if (hasChanged) {
       replace();


### PR DESCRIPTION
## Summary

We ran into a problem on Airbnb.com where we were attempting to inject a reducer into an existing namespace (intentionally), and we were getting odd behavior and no warnings or errors.

In this PR, I've added:

- a warning if an attempt is made to inject a reducer into an existing namespace.
- a `force` argument to `inject` and `injectAll` to allow forcing the injection of a reducer into an existing namespace.

I can't find a reason why injecting a reducer wouldn't work, as long as the caller understands it could have odd side effects (hence why the default is false). But there are legitimate cases where you _do_ want to override the reducer for a given namespace.

## Test Plan

Tested on airbnb.com